### PR TITLE
uses quote_plus to escape passwords

### DIFF
--- a/mqlight/client.py
+++ b/mqlight/client.py
@@ -505,9 +505,10 @@ class Client(object):
             of the second instance. If this property is not specified then
             the Client will generate a probabilistically unique ID.
         :param security_options: (optional) A dictionary that can have the
-            the following keys: "user", "password" (for SASL authentication);
+            the following keys: 
+            "property_user", "property_password" (for SASL);
             "sslTrustCertificate" specifying the path to the certificate file,
-            and sslVerifyName which is a boolean.
+            "sslVerifyName" which is a boolean.
         :param on_started: (optional) A function to be called when the Client
             reaches the started state. This function prototype must be
             ``func(client)`` ``client`` is an instance of the client.


### PR DESCRIPTION
I've noticed a lot of problems trying to connect to mqlight using a password with certain special characters.

I edited the logging bits to show the password so its a bit obvious whats going on. This is not my actual password :)

Results with urlparse.quote:

```
2016-03-15 14:25:15,271 [17107] - mqlight.client - send_11b390c - DATA attempting to connect to: amqps://N6KqE6X3MFvV:/B/G%25d%3DAAAAA@mqlightprod-ag-00002a.services.dal.bluemix.net:2906
2016-03-15 14:25:15,271 [17107] - mqlight.mqlproton - * - ENTRY >-- _MQLightSocket.__init__
2016-03-15 14:25:15,271 [17107] - mqlight.mqlproton - * - PARMS address: ('n6kqe6x3mfvv', None)
2016-03-15 14:25:15,271 [17107] - mqlight.mqlproton - * - PARMS tls: True
2016-03-15 14:25:15,271 [17107] - mqlight.mqlproton - * - PARMS security_options: SecurityOptions=(property_user: N6KqE6X3MFvV, property_password: /B/G%d=AAAAA, url_user: None,url_pass: None,ssl_trust_certificate: None, ssl_verify_name: True)
2016-03-15 14:25:15,272 [17107] - mqlight.mqlproton - * - PARMS on_read: <bound method Client._queue_on_read of <mqlight.client.Client object at 0x7f6723498690>>
2016-03-15 14:25:15,272 [17107] - mqlight.mqlproton - * - PARMS on_close: <bound method Client._queue_on_close of <mqlight.client.Client object at 0x7f6723498690>>
2016-03-15 14:25:15,272 [17107] - mqlight.mqlproton - * - DATA wrapping the socket in an SSL context
2016-03-15 14:25:15,272 [17107] - mqlight.client - send_11b390c - DATA failed to connect to: amqps://N6KqE6X3MFvV:/B/G%25d%3DAAAAA@mqlightprod-ag-00002a.services.dal.bluemix.net:2906 due to error: an integer is required
```

Results with urlparse.quote_plus

```
2016-03-15 14:20:13,972 [16258] - mqlight.client - send_30aeb1d - DATA attempting to connect to: amqps://N6KqE6X3MFvV:%2FB%2FG%25d%3AAAAA@mqlightprod-ag-00002a.services.dal.bluemix.net:2906
2016-03-15 14:20:13,972 [16258] - mqlight.mqlproton - * - ENTRY >-- _MQLightSocket.__init__
2016-03-15 14:20:13,972 [16258] - mqlight.mqlproton - * - PARMS address: ('mqlightprod-ag-00002a.services.dal.bluemix.net', 2906)
2016-03-15 14:20:13,972 [16258] - mqlight.mqlproton - * - PARMS tls: True
2016-03-15 14:20:13,972 [16258] - mqlight.mqlproton - * - PARMS security_options: SecurityOptions=(property_user: N6KqE6X3MFvV, property_password: /B/G%d=AAAAA, url_user: None,url_pass: None,ssl_trust_certificate: None, ssl_verify_name: True)
2016-03-15 14:20:13,972 [16258] - mqlight.mqlproton - * - PARMS on_read: <bound method Client._queue_on_read of <mqlight.client.Client object at 0x7f4f5dabf690>>
2016-03-15 14:20:13,972 [16258] - mqlight.mqlproton - * - PARMS on_close: <bound method Client._queue_on_close of <mqlight.client.Client object at 0x7f4f5dabf690>>
2016-03-15 14:20:13,972 [16258] - mqlight.mqlproton - * - DATA wrapping the socket in an SSL context
[SNIPPED]
2016-03-15 14:20:15,175 [16258] - mqlight.mqlproton - * - DATA outcome: 0
2016-03-15 14:20:15,175 [16258] - mqlight.mqlproton - * - EXIT <----- _update_sasl_outcome rc=None
2016-03-15 14:20:15,175 [16258] - mqlight.mqlproton - * - EXIT <---- _MQLightMessenger.started rc=True
2016-03-15 14:20:15,175 [16258] - mqlight.client - send_30aeb1d - DATA successfully connected to: amqps://N6KqE6X3MFvV:%2FB%2FG%25d%3DAAAAA@mqlightprod-ag-00002a.services.dal.bluemix.net:2906
```

I also updated the doc block for client to list the actual property name you need to use ( property_username instead of username).

I'm not sure if this should be merged against master or if this has been solved else where.
Thanks
